### PR TITLE
[View] Wizard Widget

### DIFF
--- a/LabExT/Tests/Utils.py
+++ b/LabExT/Tests/Utils.py
@@ -5,6 +5,24 @@ LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
 
+import _tkinter
+import tkinter
+from unittest import TestCase
+
+class TKinterTestCase(TestCase):
+    def setUp(self):
+        self.root=tkinter.Tk()
+        self.pump_events()
+
+    def tearDown(self):
+        if self.root:
+            self.root.destroy()
+            self.pump_events()
+
+    def pump_events(self):
+        while self.root.dooneevent(_tkinter.ALL_EVENTS | _tkinter.DONT_WAIT):
+            pass
+
 
 def ask_user_yes_no(ask_string="Is one kg of feathers lighter than one kg of iron?", default_answer=True):
     """ Ask the user a yes/no question:

--- a/LabExT/Tests/Utils.py
+++ b/LabExT/Tests/Utils.py
@@ -5,13 +5,15 @@ LabExT  Copyright (C) 2021  ETH Zurich and Polariton Technologies AG
 This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
 """
 
+
 import _tkinter
 import tkinter
 from unittest import TestCase
 
+
 class TKinterTestCase(TestCase):
     def setUp(self):
-        self.root=tkinter.Tk()
+        self.root = tkinter.Tk()
         self.pump_events()
 
     def tearDown(self):

--- a/LabExT/Tests/View/Controls/Wizard_test.py
+++ b/LabExT/Tests/View/Controls/Wizard_test.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+from unittest.mock import Mock
+from LabExT.Tests.Utils import TKinterTestCase
+
+import tkinter
+from LabExT.View.Controls.Wizard import Step, Wizard
+
+
+class WizardUnitTest(TKinterTestCase):
+    """
+    Unittests for Wizard Widget.
+
+    These tests do not test appearance, but functionality.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.wizard = Wizard(
+            self.root,
+            next_button_label="Custom Next Label",
+            previous_button_label="Custom Previous Label",
+            cancel_button_label="Custom Cancel Label",
+            finish_button_label="Custom Finish Label"
+        )
+        self.builder = Mock()
+
+    def test_wizard_build(self):
+        self.assertEqual(self.wizard._next_button['text'], "Custom Next Label")
+        self.assertEqual(
+            self.wizard._previous_button['text'],
+            "Custom Previous Label")
+        self.assertEqual(
+            self.wizard._cancel_button['text'],
+            "Custom Cancel Label")
+        self.assertEqual(
+            self.wizard._finish_button['text'],
+            "Custom Finish Label")
+
+    def test_add_step_handle_callbacks(self):
+        on_reload = Mock()
+        on_next = Mock()
+        on_previous = Mock()
+
+        step = self.wizard.add_step(
+            builder=lambda: None,
+            on_reload=on_reload,
+            on_next=on_next,
+            on_previous=on_previous)
+
+        step.on_next_callback()
+        on_next.assert_called_once()
+
+        step.on_previous_callback()
+        on_previous.assert_called_once()
+
+        step.on_reload_callback()
+        on_reload.assert_called_once()
+
+    def test_add_step_handle_step_linking(self):
+        step = self.wizard.add_step(builder=lambda: None)
+        previous_step = self.wizard.add_step(builder=lambda: None)
+        next_step = self.wizard.add_step(builder=lambda: None)
+
+        # Link Three step as a chain
+        previous_step.next_step = step
+        step.previous_step = previous_step
+        step.next_step = next_step
+        next_step.previous_step = step
+
+        # Check if previous_step knows all its linkings
+        self.assertFalse(previous_step.previous_step_available)
+        self.assertIsNone(previous_step.previous_step)
+        self.assertTrue(previous_step.next_step_available)
+        self.assertEqual(previous_step.next_step, step)
+
+        # Check if step knows all its linkings
+        self.assertTrue(step.previous_step_available)
+        self.assertEqual(step.previous_step, previous_step)
+        self.assertTrue(step.next_step_available)
+        self.assertEqual(step.next_step, next_step)
+
+        # Check if next_step knows all its linkings
+        self.assertTrue(next_step.previous_step_available)
+        self.assertEqual(next_step.previous_step, step)
+        self.assertFalse(next_step.next_step_available)
+        self.assertIsNone(next_step.next_step)
+
+    def test_add_step_creates_new_sidebar_label(self):
+        step = self.wizard.add_step(
+            builder=lambda: None,
+            title="My Custom Step")
+
+        self.assertIsNotNone(step._sidebar_label)
+        self.assertEqual(step._sidebar_label['text'], "My Custom Step")
+        self.assertEqual(
+            step._sidebar_label['foreground'],
+            Step.INACTIVE_LABEL_COLOR)
+
+        step.activate_sidebar_label()
+        self.assertEqual(
+            step._sidebar_label['foreground'],
+            Step.ACTIVE_LABEL_COLOR)
+
+        step.deactivate_sidebar_label()
+        self.assertEqual(
+            step._sidebar_label['foreground'],
+            Step.INACTIVE_LABEL_COLOR)
+
+    # Testing current step
+
+    def test_next_step_if_next_step_is_present(self):
+        on_next = Mock(return_value=False)
+        current_step = self.wizard.add_step(
+            builder=self.builder, on_next=on_next)
+        self.wizard.current_step = current_step
+
+        # Nothing happens, if current step has no next step
+        self.wizard._next_button.invoke()
+        self.pump_events()
+
+        on_next.assert_not_called()
+        self.assertEqual(self.wizard.current_step, current_step)
+
+    def test_next_step_if_next_step_callback_fails(self):
+        on_next = Mock(return_value=False)
+        next_builder = Mock()
+
+        current_step = self.wizard.add_step(
+            builder=self.builder, on_next=on_next)
+        next_step = self.wizard.add_step(builder=next_builder)
+        current_step.next_step = next_step
+
+        self.wizard.current_step = current_step
+        self.wizard._next_button.invoke()
+        self.pump_events()
+
+        on_next.assert_called_once()
+        self.assertEqual(self.wizard.current_step, current_step)
+        next_builder.assert_not_called()
+
+    def test_next_step_if_next_step_callback_succeeds(self):
+        on_next = Mock(return_value=True)
+        next_builder = Mock()
+
+        current_step = self.wizard.add_step(
+            builder=self.builder, on_next=on_next)
+        next_step = self.wizard.add_step(builder=next_builder)
+        current_step.next_step = next_step
+
+        self.wizard.current_step = current_step
+        self.wizard._next_button.invoke()
+        self.pump_events()
+
+        on_next.assert_called_once()
+        self.assertEqual(self.wizard.current_step, next_step)
+        next_builder.assert_called_once()
+
+    def test_previous_step_if_previous_step_is_present(self):
+        on_previous = Mock(return_value=False)
+        current_step = self.wizard.add_step(
+            builder=self.builder, on_previous=on_previous)
+        self.wizard.current_step = current_step
+
+        # Nothing happens, if current step has no next step
+        self.wizard._previous_button.invoke()
+        self.pump_events()
+
+        on_previous.assert_not_called()
+        self.assertEqual(self.wizard.current_step, current_step)
+
+    def test_previous_step_if_previous_step_callback_fails(self):
+        on_previous = Mock(return_value=False)
+        previous_builder = Mock()
+
+        current_step = self.wizard.add_step(
+            builder=self.builder, on_previous=on_previous)
+        previous_step = self.wizard.add_step(builder=previous_builder)
+        current_step.previous_step = previous_step
+
+        self.wizard.current_step = current_step
+        self.wizard._previous_button.invoke()
+        self.pump_events()
+
+        on_previous.assert_called_once()
+        self.assertEqual(self.wizard.current_step, current_step)
+        previous_builder.assert_not_called()
+
+    def test_previous_step_if_previous_step_callback_succeeds(self):
+        on_previous = Mock(return_value=True)
+        previous_builder = Mock()
+
+        current_step = self.wizard.add_step(
+            builder=self.builder, on_previous=on_previous)
+        previous_step = self.wizard.add_step(builder=previous_builder)
+        current_step.previous_step = previous_step
+
+        self.wizard.current_step = current_step
+        self.wizard._previous_button.invoke()
+        self.pump_events()
+
+        on_previous.assert_called_once()
+        self.assertEqual(self.wizard.current_step, previous_step)
+        previous_builder.assert_called_once()
+
+    def test_current_step_changes_sidebar_config(self):
+        current_step = self.wizard.add_step(
+            builder=self.builder, title="Current Step")
+        self.wizard._current_step = current_step
+
+        step = self.wizard.add_step(
+            builder=self.builder,
+            title="My Custom Step")
+        self.wizard.current_step = step
+
+        self.assertEqual(
+            current_step._sidebar_label['foreground'],
+            Step.INACTIVE_LABEL_COLOR)
+        self.assertEqual(
+            step._sidebar_label['foreground'],
+            Step.ACTIVE_LABEL_COLOR)
+        self.assertEqual(self.wizard.current_step, step)
+
+    def test_current_step_renders_new_frame(self):
+        current_step = self.wizard.add_step(
+            builder=self.builder, title="Current Step")
+        self.wizard.current_step = current_step
+
+        self.builder.assert_called_once()
+
+    def test_current_step_calls_reload_callback(self):
+        on_reload = Mock()
+
+        current_step = self.wizard.add_step(
+            builder=self.builder, on_reload=on_reload)
+        self.wizard.current_step = current_step
+
+        on_reload.assert_called_once()
+
+
+class WizardIntegrationTest(TKinterTestCase):
+    """
+    Integration test for a Wizard with 2 steps.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.on_finish = Mock()
+        self.on_cancel = Mock()
+        self.wizard = Wizard(
+            self.root,
+            on_cancel=self.on_cancel,
+            on_finish=self.on_finish)
+
+        self.first_step_builder = Mock()
+        self.first_step_on_reload = Mock()
+        self.first_step_on_next = Mock()
+        self.first_step_on_previous = Mock()
+        self.first_step = self.wizard.add_step(
+            builder=self.first_step_builder,
+            on_next=self.first_step_on_next,
+            on_previous=self.first_step_on_previous,
+            on_reload=self.first_step_on_reload,
+            title="First Step"
+        )
+
+        self.second_step_builder = Mock()
+        self.second_step_on_reload = Mock()
+        self.second_step_on_next = Mock()
+        self.second_step_on_previous = Mock()
+        self.second_step = self.wizard.add_step(
+            builder=self.second_step_builder,
+            on_next=self.second_step_on_next,
+            on_previous=self.second_step_on_previous,
+            on_reload=self.second_step_on_reload,
+            title="Second Step"
+        )
+
+        self.first_step.next_step = self.second_step
+        self.second_step.previous_step = self.first_step
+
+    def assertSidebarLabelColor(self, first_step, second_step):
+        self.assertEqual(
+            self.first_step._sidebar_label['foreground'],
+            first_step)
+        self.assertEqual(
+            self.second_step._sidebar_label['foreground'],
+            second_step)
+
+    def assertButtonState(
+            self,
+            next=tkinter.NORMAL,
+            previous=tkinter.NORMAL,
+            cancel=tkinter.NORMAL,
+            finish=tkinter.NORMAL):
+        self.assertEqual(self.wizard._next_button['state'], next)
+        self.assertEqual(self.wizard._previous_button['state'], previous)
+        self.assertEqual(self.wizard._cancel_button['state'], cancel)
+        self.assertEqual(self.wizard._finish_button['state'], finish)
+
+    def test_next_from_first_step(self):
+        self.wizard.current_step = self.first_step
+
+        self.first_step_builder.assert_called_once()
+        self.first_step_on_reload.assert_called_once()
+        self.assertSidebarLabelColor(
+            first_step=Step.ACTIVE_LABEL_COLOR,
+            second_step=Step.INACTIVE_LABEL_COLOR
+        )
+        self.assertButtonState(
+            previous=tkinter.DISABLED,
+            next=tkinter.NORMAL,
+            finish=tkinter.DISABLED
+        )
+
+        # Move to next step
+        self.wizard._next_button.invoke()
+        self.pump_events()
+
+        self.first_step_on_next.assert_called_once()
+        self.second_step_builder.assert_called_once()
+        self.second_step_on_reload.assert_called_once()
+
+        self.assertSidebarLabelColor(
+            first_step=Step.INACTIVE_LABEL_COLOR,
+            second_step=Step.ACTIVE_LABEL_COLOR
+        )
+        self.assertButtonState(
+            previous=tkinter.NORMAL,
+            next=tkinter.DISABLED,
+            finish=tkinter.DISABLED
+        )
+
+    def test_previous_from_first_step(self):
+        self.wizard.current_step = self.first_step
+
+        # Move to previous step
+        self.wizard._previous_button.invoke()
+        self.pump_events()
+
+        self.first_step_builder.assert_called_once()
+        self.first_step_on_previous.assert_not_called()
+        self.assertSidebarLabelColor(
+            first_step=Step.ACTIVE_LABEL_COLOR,
+            second_step=Step.INACTIVE_LABEL_COLOR
+        )
+        self.assertButtonState(
+            previous=tkinter.DISABLED,
+            next=tkinter.NORMAL,
+            finish=tkinter.DISABLED
+        )
+
+    def test_next_from_second_step(self):
+        self.wizard.current_step = self.second_step
+
+        # Move to next step
+        self.wizard._next_button.invoke()
+        self.pump_events()
+
+        self.second_step_builder.assert_called_once()
+        self.second_step_on_next.assert_not_called()
+        self.assertSidebarLabelColor(
+            first_step=Step.INACTIVE_LABEL_COLOR,
+            second_step=Step.ACTIVE_LABEL_COLOR
+        )
+        self.assertButtonState(
+            previous=tkinter.NORMAL,
+            next=tkinter.DISABLED,
+            finish=tkinter.DISABLED
+        )
+
+    def test_previous_from_second_step(self):
+        self.wizard.current_step = self.second_step
+
+        self.second_step_builder.assert_called_once()
+        self.second_step_on_reload.assert_called_once()
+        self.assertSidebarLabelColor(
+            first_step=Step.INACTIVE_LABEL_COLOR,
+            second_step=Step.ACTIVE_LABEL_COLOR
+        )
+        self.assertButtonState(
+            previous=tkinter.NORMAL,
+            next=tkinter.DISABLED,
+            finish=tkinter.DISABLED
+        )
+
+        # Move to next step
+        self.wizard._previous_button.invoke()
+        self.pump_events()
+
+        self.second_step_on_previous.assert_called_once()
+        self.first_step_builder.assert_called_once()
+        self.first_step_on_reload.assert_called_once()
+
+        self.assertSidebarLabelColor(
+            first_step=Step.ACTIVE_LABEL_COLOR,
+            second_step=Step.INACTIVE_LABEL_COLOR
+        )
+        self.assertButtonState(
+            previous=tkinter.DISABLED,
+            next=tkinter.NORMAL,
+            finish=tkinter.DISABLED
+        )
+
+    def test_finish(self):
+        self.wizard.current_step = self.first_step
+        self.first_step.finish_step_enabled = False
+
+        self.assertEqual(self.wizard._finish_button['state'], tkinter.DISABLED)
+
+        self.wizard._finish_button.invoke()
+        self.pump_events()
+
+        self.on_finish.assert_not_called()
+
+        self.first_step.finish_step_enabled = True
+        self.wizard.__reload__()
+
+        self.assertEqual(self.wizard._finish_button['state'], tkinter.NORMAL)
+
+        self.wizard._finish_button.invoke()
+        self.pump_events()
+
+        self.on_finish.assert_called_once()
+
+    def test_cancel(self):
+        self.wizard.current_step = self.first_step
+
+        self.wizard._cancel_button.invoke()
+        self.pump_events()
+
+        self.on_cancel.assert_called_once()

--- a/LabExT/View/Controls/Wizard.py
+++ b/LabExT/View/Controls/Wizard.py
@@ -144,8 +144,8 @@ class Wizard(Toplevel):
             height=480,
             on_cancel=None,
             on_finish=None,
-            withSidebar=True,
-            withError=True,
+            with_sidebar=True,
+            with_error=True,
             next_button_label="Next Step",
             previous_button_label="Previous Step",
             cancel_button_label="Cancel",
@@ -166,7 +166,7 @@ class Wizard(Toplevel):
         self.on_finish = on_finish
 
         # Build Wizard
-        if withSidebar:
+        if with_sidebar:
             self._sidebar_frame = CustomFrame(self, width=self.SIDEBAR_WIDTH)
             self._sidebar_frame.pack(side=LEFT, fill=BOTH, anchor='nw')
         else:
@@ -181,7 +181,7 @@ class Wizard(Toplevel):
             relief=FLAT)
         self._main_frame.pack(side=TOP, fill=BOTH, expand=True)
 
-        if withError:
+        if with_error:
             self._error_frame = Frame(
                 self._content_frame, borderwidth=0, relief=FLAT)
             self._error_frame.pack(side=TOP, fill=X, padx=10, expand=0)
@@ -235,7 +235,7 @@ class Wizard(Toplevel):
             side=RIGHT, fill=Y, expand=0, padx=5, pady=10)
 
         self.wm_geometry("{width:d}x{height:d}".format(
-            width=width + self.SIDEBAR_WIDTH if withSidebar else width,
+            width=width + self.SIDEBAR_WIDTH if with_sidebar else width,
             height=height))
         self.protocol('WM_DELETE_WINDOW', self._cancel)
 

--- a/LabExT/View/Controls/Wizard.py
+++ b/LabExT/View/Controls/Wizard.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LabExT  Copyright (C) 2022  ETH Zurich and Polariton Technologies AG
+This program is free software and comes with ABSOLUTELY NO WARRANTY; for details see LICENSE file.
+"""
+
+from tkinter import Label, Toplevel, Frame, Button, FLAT, TOP, RIGHT, LEFT, X, Y, BOTH, NORMAL, DISABLED
+from typing import Type
+
+
+from LabExT.View.Controls.CustomFrame import CustomFrame
+
+
+class Step:
+    """
+    Implementation of one Wizard Step.
+    """
+
+    ACTIVE_LABEL_COLOR = "#000000"
+    INACTIVE_LABEL_COLOR = "#808080"
+
+    def __init__(
+            self,
+            wizard,
+            builder,
+            title=None,
+            on_next=None,
+            on_previous=None,
+            on_reload=None,
+            previous_step_enabled=True,
+            next_step_enabled=True,
+            finish_step_enabled=False) -> None:
+        """
+        Constructor for a Wizard Step.
+        """
+        self.wizard: Type[Wizard] = wizard
+
+        self.builder = builder
+
+        self.on_next = on_next
+        self.on_previous = on_previous
+        self.on_reload = on_reload
+
+        self.previous_step: Type[Step] = None
+        self.next_step: Type[Step] = None
+
+        self.previous_step_enabled = previous_step_enabled
+        self.next_step_enabled = next_step_enabled
+        self.finish_step_enabled = finish_step_enabled
+
+        if self.wizard._sidebar_frame and title:
+            self._sidebar_label = Label(
+                self.wizard._sidebar_frame,
+                anchor="w",
+                text=title,
+                foreground=self.INACTIVE_LABEL_COLOR)
+            self._sidebar_label.pack(side=TOP, fill=X, padx=10, pady=5)
+        else:
+            self._sidebar_label = None
+
+    def activate_sidebar_label(self):
+        """
+        Changes sidebar label to active color
+        """
+        if not self._sidebar_label:
+            return
+
+        self._sidebar_label.config(foreground=self.ACTIVE_LABEL_COLOR)
+
+    def deactivate_sidebar_label(self):
+        """
+        Changes sidebar label to inactive color
+        """
+        if not self._sidebar_label:
+            return
+
+        self._sidebar_label.config(foreground=self.INACTIVE_LABEL_COLOR)
+
+    @property
+    def previous_step_available(self):
+        """
+        Returns a decision, if a previous step is available.
+
+        A previous step is available if the current step is defined and enabled.
+        """
+        return self.previous_step is not None and self.previous_step_enabled
+
+    @property
+    def next_step_available(self):
+        """
+        Returns a decision, if a next step is available.
+
+        A next step is available if the current step is defined and enabled.
+        """
+        return self.next_step is not None and self.next_step_enabled
+
+    def on_next_callback(self):
+        """
+        Performs on_next callback.
+
+        Returns True if callback not defined or callback succeeds, False otherwise.
+        """
+        if not self.on_next:
+            return True
+
+        return self.on_next()
+
+    def on_previous_callback(self):
+        """
+        Performs on_update callback.
+
+        Returns True if callback not defined or callback succeeds, False otherwise.
+        """
+        if not self.on_previous:
+            return True
+
+        return self.on_previous()
+
+    def on_reload_callback(self):
+        """
+        Performs on_reload callback.
+
+        Returns True if callback not defined or callback succeeds, False otherwise.
+        """
+        if not self.on_reload:
+            return
+
+        self.on_reload()
+
+
+class Wizard(Toplevel):
+    """
+    Implementation of a Wizard Widget.
+    """
+    SIDEBAR_WIDTH = 200
+
+    ERROR_COLOR = "#FF3333"
+
+    def __init__(
+            self,
+            parent,
+            width=640,
+            height=480,
+            on_cancel=None,
+            on_finish=None,
+            withSidebar=True,
+            withError=True,
+            next_button_label="Next Step",
+            previous_button_label="Previous Step",
+            cancel_button_label="Cancel",
+            finish_button_label="Finish") -> None:
+        Toplevel.__init__(
+            self,
+            parent,
+            borderwidth=0,
+            highlightthickness=0,
+            takefocus=0,
+            relief=FLAT)
+
+        self.parent = parent
+
+        self._current_step: Type[Step] = None
+
+        self.on_cancel = on_cancel
+        self.on_finish = on_finish
+
+        # Build Wizard
+        if withSidebar:
+            self._sidebar_frame = CustomFrame(self, width=self.SIDEBAR_WIDTH)
+            self._sidebar_frame.pack(side=LEFT, fill=BOTH, anchor='nw')
+        else:
+            self._sidebar_frame = None
+
+        self._content_frame = Frame(self, borderwidth=0, relief=FLAT)
+        self._content_frame.pack(side=RIGHT, fill=BOTH, expand=True)
+
+        self._main_frame = Frame(
+            self._content_frame,
+            borderwidth=0,
+            relief=FLAT)
+        self._main_frame.pack(side=TOP, fill=BOTH, expand=True)
+
+        if withError:
+            self._error_frame = Frame(
+                self._content_frame, borderwidth=0, relief=FLAT)
+            self._error_frame.pack(side=TOP, fill=X, padx=10, expand=0)
+            self._error_label = Label(
+                self._error_frame,
+                text=None,
+                foreground=self.ERROR_COLOR,
+                anchor="w")
+            self._error_label.pack(side=LEFT, fill=X)
+        else:
+            self._error_label = None
+
+        self._control_frame = Frame(
+            self._content_frame,
+            borderwidth=0,
+            highlightthickness=0,
+            takefocus=0)
+        self._control_frame.pack(side=TOP, fill=X, expand=0)
+
+        self._cancel_button = Button(
+            self._control_frame,
+            text=cancel_button_label,
+            width=10,
+            command=self._cancel)
+        self._cancel_button.pack(
+            side=RIGHT, fill=Y, expand=0, padx=(
+                5, 10), pady=10)
+
+        self._finish_button = Button(
+            self._control_frame,
+            text=finish_button_label,
+            width=10,
+            command=self._finish)
+        self._finish_button.pack(
+            side=RIGHT, fill=Y, expand=0, padx=(
+                20, 5), pady=10)
+
+        self._next_button = Button(
+            self._control_frame,
+            text=next_button_label,
+            width=10,
+            command=self._next_step)
+        self._next_button.pack(side=RIGHT, fill=Y, expand=0, padx=5, pady=10)
+
+        self._previous_button = Button(
+            self._control_frame,
+            text=previous_button_label,
+            width=10,
+            command=self._previous_step)
+        self._previous_button.pack(
+            side=RIGHT, fill=Y, expand=0, padx=5, pady=10)
+
+        self.wm_geometry("{width:d}x{height:d}".format(
+            width=width + self.SIDEBAR_WIDTH if withSidebar else width,
+            height=height))
+        self.protocol('WM_DELETE_WINDOW', self._cancel)
+
+    @property
+    def current_step(self) -> Type[Step]:
+        """
+        Returns the current step object.
+        """
+        return self._current_step
+
+    @current_step.setter
+    def current_step(self, step: Type[Step]) -> None:
+        """
+        Sets the current step, updates the sidebar and resets error.
+
+        Reloads Wizard afterwards.
+        """
+        if self._current_step:
+            self._current_step.deactivate_sidebar_label()
+
+        if step:
+            step.activate_sidebar_label()
+
+        self.set_error("")
+
+        self._current_step = step
+        self.__reload__()
+
+    def __reload__(self):
+        """
+        Updates the Wizard contents.
+        """
+        self.current_step.on_reload_callback()
+
+        # Update Button States
+        self._previous_button.config(
+            state=NORMAL if self.current_step.previous_step_available else DISABLED)
+        self._next_button.config(
+            state=NORMAL if self.current_step.next_step_available else DISABLED)
+        self._finish_button.config(
+            state=NORMAL if self.current_step.finish_step_enabled else DISABLED)
+
+        # Remove all widgets in main frame
+        for child in self._main_frame.winfo_children():
+            child.forget()
+
+        # Create step frame and build it by calling step builder
+        step_frame = CustomFrame(self._main_frame)
+        self.current_step.builder(step_frame)
+        step_frame.pack(side=LEFT, fill=BOTH, padx=10, pady=(10, 2), expand=1)
+
+        self.update_idletasks()
+
+    def add_step(self, *args, **kwargs) -> Type[Step]:
+        """
+        Creates and returns a new wizard step.
+        """
+        return Step(self, *args, **kwargs)
+
+    def set_error(self, message):
+        if not self._error_label:
+            return
+
+        self._error_label.config(text=message)
+
+    def _finish(self):
+        """
+        Gets called, when user clicks finish button
+        """
+        if not self.current_step.finish_step_enabled:
+            return
+
+        if self._on_finish_callback():
+            self.destroy()
+
+    def _cancel(self):
+        """
+        Gets called, when user clicks cancel button
+        """
+        if self._on_cancel_callback():
+            self.destroy()
+
+    def _previous_step(self):
+        """
+        Gets called, when user clicks previous step button
+        """
+        if not self.current_step.previous_step_available:
+            return
+
+        if not self.current_step.on_previous_callback():
+            return
+
+        self.current_step = self.current_step.previous_step
+
+    def _next_step(self):
+        """
+        Gets called, when user clicks next step button
+        """
+        if not self.current_step.next_step_available:
+            return
+
+        if not self._current_step.on_next_callback():
+            return
+
+        self.current_step = self._current_step.next_step
+
+    def _on_cancel_callback(self) -> bool:
+        """
+        Performs on_cancel callback.
+
+        Returns True if callback not defined or callback succeeds, False otherwise.
+        """
+        if not self.on_cancel:
+            return True
+
+        return self.on_cancel()
+
+    def _on_finish_callback(self) -> bool:
+        """
+        Performs on_finish callback.
+
+        Returns True if callback not defined or callback succeeds, False otherwise.
+        """
+        if not self.on_finish:
+            return True
+
+        return self.on_finish()

--- a/tox.ini
+++ b/tox.ini
@@ -13,5 +13,6 @@ python =
 [testenv]
 deps =
     pytest
+    pytest-xvfb
 commands =
     pytest


### PR DESCRIPTION
# TL;DR: Wizard Widget
This pull request adds a widget to easily create wizard windows in LabExT. Detailed documentation on how to use it can be found below. Tests have been added to test functionality (e.g. button clicks) rather than appearance. 

**The code does not break any existing code. It simply adds code that is not already in use.**

# How to use the widget:
## 1. Basic settings
Create a class that inherits from `Wizard`. Call the `Wizard` constructor to set the basic settings. 
```python
from LabExT.View.Controls.Wizard import Wizard

class MyWizard(Wizard):
    def __init__(self, parent):
         super().__init__(
             parent, # required
             width=800, # Default: 640
             height=600, # Default: 480
             withSidebar=True, # Default: True
             withError=True, # Default: True
             on_cancel=self._cancel, # not required
             on_finish=self._save, # not required
             next_button_label="Next Step" # Default: "Next Step"
             previous_button_label="Previous Step", # Default: Previous Step
             cancel_button_label="Cancel and Close", # Default: Cancel
             finish_button_label="Finish and Save" # Default: Finish
         )
    ...
```
### Explanation of the settings
- `width` and `height` sets the dimension of the wizard window.
-  `withSidebar` activates the step overview of the wizard. A frame with a width of 200 is created to the right of the content, displaying the titles of all steps and highlighting the current step. 
- `withError` activates the error display function of the wizard. When the wizard function `setError("Error: ...")` is called, the error is displayed in red above the buttons.
- `on_cancel` is the callback function that is called when the user closes the window or clicks Cancel. This method is **blocking**. The method is expected to return a bool. If the return value is True, the window is closed, otherwise it remains open.
- `on_finish` is the callback method that is called when the user clicks on Finish. This method is **blocking**. The method is expected to return a bool. If the return value is True, the window is closed, otherwise it remains open.
- `next_button_label`, `previous_button_label`, `cancel_button_label` and `finish_button_label ` are used to change the button labels.

**Note:** The `Wizard` class itself inherits from the Tkinter class `Toplevel.` Therefore, well-known functions such as `title` are available on `self`.

## 2. Define new step
To add new steps to the wizard, the method `add_step` is used. It is recommended to define the steps in the constructor of your wizard class.
```python
self.connection_step = self.add_step(
    builder=self._connection_step_builder, " required
    title="Stage Connection", # Default: None
    on_next=self._on_next, # not required
    on_previous=self._on_previous, # not required
    on_reload=self._on_reload, # not required
    previous_step_enabled=True, # Default: True
    next_step_enabled=True, # Default: True
    finish_step_enabled=False # Default: False
)
```
### Explanation of the settings
- `builder` is the routine that builds the wizard step, i.e. defines all Tkinter objects. A Tkinter `Frame`-object is passed to the method as the first argument. All elements should use this frame as parent. The builder method is called every time the step is displayed or the wizard is manually reloaded, i.e. it is possible to render the step conditionally based on same state.
- `title` defines an optional title for the sidebar, if this has been activated.
- `on_next` is the callback method when the user clicks on "Next step". This method is **blocking**. The method is expected to return a bool. If the return value is True, the next step is loaded, otherwise not.
- `on_previous ` is the callback method when the user clicks on "Previous step". This method is **blocking**. The method is expected to return a bool. If the return value is True, the previous step is loaded, otherwise not.
- `on_reload` is called every time the step is "built", i.e. the builder method is called. This happens during step changes or when the `__reload__` method is called manually. Exemplary use: To check the current wizard state for errors:
```python
def _check_assignment(self):
    if is_stage_assignment_valid(self._current_stage_assignment):
        self.current_step.next_step_enabled = True
        self.set_error("")
    else:
        self.current_step.next_step_enabled = False
        self.set_error("Please assign at least one stage and do not select a stage twice.")
```
- `next_step_enabled ` activates the next step button. Note: This property can also be changed after the step creation (see code above).
- `previous_step_enabled ` activates the previous step button. Note: This property can also be changed after the step creation (see code above).
- `finish_step_enabled`  activates the finish button. Note: This property can also be changed after the step creation (see code above).

## 3. Define step sequence
Use the `next_step` and `previous_step` properties of the steps to define the order. Note: The order can also be changed on the fly.
```python
# Connect Steps
self.first_step.next_step = self.second_step
self.second_step.previous_step = self.first_step
self.second_step.next_step = self.third_step
self.third_step.previous_step = self.third_step
```

## 4. Define first step
To start the wizard, the first step must be defined.
```python
self.current_step = self.first_step
```

## Miscellaneous
- Use `__reload__` to reload the wizard. The method calls the builder again and updates all button and sidebar states.
- Use the `set_error(str)` method to indicate an error. Note: To reset the error, use `set_error("")`